### PR TITLE
Layout redon

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -79,16 +79,27 @@ class App extends Component {
       : null
     )
 
+    const style = {
+      display : "grid",
+      height : "100vh",
+      alignItems : "flex-start"
+    }
+
+    const rowStyle = {
+      height : "100%",
+      marginBottom : "0"
+    }
+
     if (localStorage.getItem("jwtToken") !== "undefined" && localStorage.getItem("jwtToken") !== null) {
       // logged-in
       return (
-        <div className="App ">
+        <div className="App " style={style}>
 
           <Nav addPark={this.props.addPark} handleLogOut={this.handleLogOut} />
 
           {modalForm}
 
-          <Row>
+          <Row style={rowStyle}>
             <Col s={6}>
           
               <ParksContainer

--- a/client/src/components/Parks.js
+++ b/client/src/components/Parks.js
@@ -18,9 +18,17 @@ const Parks = ({ deletePark, editPark, parks, checkIn, fetchCurrentUsers}) => {
     });
   };
 
+  const style = {
+    heigt : "100%"
+  }
+
+  const rowStyle = {
+    marginBottom : "0"
+  }
+
   return (
-    <div className="Parks">
-      <Row>
+    <div className="Parks" style={style} >
+      <Row style={rowStyle}>
         {renderParks()} 
       
       </Row>

--- a/client/src/containers/MapContainer.js
+++ b/client/src/containers/MapContainer.js
@@ -48,15 +48,15 @@ export class MapContainer extends Component {
 
   render() {
     const style = {
-      width: "50%",
-      height: "100%"
+      width: "100%",
+      height: "90vh",
+      position : "relative"
     };
 
     return (
-      <div className="Map-container">
+      <div className="Map-container" style={style}>
         <Map
           google={this.props.google}
-          style={style}
           center={this.state.currentLocation}
           zoom={13}
           onClick={this.onMapClicked}

--- a/client/src/containers/ParksContainer.js
+++ b/client/src/containers/ParksContainer.js
@@ -11,7 +11,7 @@ class ParksContainer extends Component {
   render(){
 
     const style = {
-      height : "100%"
+      height : "90vh"
     }
 
     return <div style={style} className="Parks-container">

--- a/client/src/containers/ParksContainer.js
+++ b/client/src/containers/ParksContainer.js
@@ -9,7 +9,12 @@ class ParksContainer extends Component {
 
   
   render(){
-    return <div className="Parks-container">
+
+    const style = {
+      height : "100%"
+    }
+
+    return <div style={style} className="Parks-container">
         <Parks 
           deletePark={this.props.deletePark}
           editPark={this.props.editPark} 


### PR DESCRIPTION
Fix for [[task] Fix Map CSS #20](https://github.com/katleiahramos/Bark-Park/issues/20)

First of all this pull request fixes the extra space to the right but by fixing that it created problems with having to set the height of the map to a fixed height. (e.g. parks to 600px)

So I have done a simple re-layout of turning the display into a grid with 2 rows. Top row is for the header, the bottom row is for the content/view, this makes it possible for everything to be responsive within the viewport.

**Improvements**
- More responsive Design
- Map fits within viewport
- No extra white/scroll right and bottom
- Parks Container scroll point and Map Container Bottom Point line up

**Suggestions**
- Map has slight padding around it, this can be removed, there is a div surrounding the mapContainer that I can see in inspector from allowing the map to cover the full height and I can't find it in any files, if you have any knowledge about this ,that would be great 
- This is a quick fix for desktop for users but more work will have to be done on the css to acheive true responsive design for users on smaller devices

Pull request can be pulled back to the commit where only the right side space was fixed, if requested